### PR TITLE
商品情報編集機能

### DIFF
--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -227,3 +227,8 @@
 .inc {
   font-size: 13px;
 }
+
+.error-message {
+  color: red;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -50,7 +50,7 @@
 }
 
 
-.item-red-btn {
+.your-button-class {
   text-align: center;
   background-color: #ea352d;
   font-size: 24px;
@@ -64,7 +64,7 @@
   font-size: 20px;
 }
 
-.item-destroy {
+.btn-delete {
   background-color: lightgray;
   text-align: center;
   font-size: 24px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,15 +23,19 @@ class ItemsController < ApplicationController
     @items = Item.all.order(created_at: :desc)
   end
 
-  def edit_item
+  def edit
     @item = Item.find(params[:id])
-    # 出品者としてログインしていないか、商品の出品者ではない場合はリダイレクト
-    if current_user == @item.user
-      render 'edit' # 編集画面に遷移
+  
+    if user_signed_in?
+      if current_user == @item.user && !@item.sold?
+        # ユーザーがログインし、出品者かつ商品が売却済みでない場合は編集ページに遷移
+      else
+        redirect_to root_path
+      end
     else
-      redirect_to item_path(@item)
+      redirect_to new_user_session_path  # ログアウトユーザーはログインページに遷移
     end
-  end      
+  end        
 
   def update
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def new
     @item = Item.new
@@ -15,7 +16,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
     @user_is_seller = user_signed_in? && current_user == @item.user
   end
 
@@ -24,30 +24,22 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
-  
-    if user_signed_in?
-      if current_user == @item.user
-        # ユーザーがログインし、出品者かつ商品が売却済みでない場合は編集ページに遷移
-      else
-        redirect_to root_path
-      end
+    if current_user == @item.user
+      # ユーザーがログインし、出品者かつ商品が売却済みでない場合は編集ページに遷移
     else
-      redirect_to new_user_session_path  # ログアウトユーザーはログインページに遷移
+      redirect_to root_path
     end
-  end        
+  end
 
   def update
-    @item = Item.find(params[:id])
-  
     # フォームから送信された画像を取得
     new_image = params[:item][:image]
-  
+
     # 画像が選択されていない場合、既存の画像を保持する
     if new_image.blank?
       @item.image.attach(@item.image.blob) if @item.image.attached?
     else
-    # 新しい画像が送信された場合、既存の画像を置き換える
+      # 新しい画像が送信された場合、既存の画像を置き換える
       @item.image.purge
       @item.image.attach(new_image)
     end
@@ -60,8 +52,12 @@ class ItemsController < ApplicationController
       render 'edit'
     end
   end
-  
+
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(:name, :item_info, :category_id, :condition_id, :shipping_id, :prefecture_id, :delivery_day_id, :price, :image)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,9 +23,15 @@ class ItemsController < ApplicationController
     @items = Item.all.order(created_at: :desc)
   end
 
-  def edit
+  def edit_item
     @item = Item.find(params[:id])
-  end  
+    # 出品者としてログインしていないか、商品の出品者ではない場合はリダイレクト
+    if current_user == @item.user
+      render 'edit' # 編集画面に遷移
+    else
+      redirect_to item_path(@item)
+    end
+  end      
 
   def update
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,13 +29,25 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-    if @item.update(item_params)
+  
+    # フォームから送信された画像を取得
+    new_image = params[:item][:image]
+  
+    if new_image.present?
+      # 新しい画像が送信された場合、既存の画像を置き換える
+      @item.image.purge
+      @item.image.attach(new_image)
+    end
+  
+    if @item.update(item_params.except(:image))
+      # 商品情報が正常に更新された場合の処理
       redirect_to @item, notice: "商品情報が更新されました。"
     else
+      # 商品情報の更新にエラーがある場合の処理
       render 'edit'
     end
   end
-  
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,11 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-  end
+    if @item.update_in_progress?
+      @item.discard_changes
+    end
+    redirect_to item_path(@item)
+  end  
 
   def update
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,29 +37,29 @@ class ItemsController < ApplicationController
     end
   end        
 
-def update
-  @item = Item.find(params[:id])
+  def update
+    @item = Item.find(params[:id])
   
-  # フォームから送信された画像を取得
-  new_image = params[:item][:image]
+    # フォームから送信された画像を取得
+    new_image = params[:item][:image]
   
-  # 画像が選択されていない場合、既存の画像を保持する
-  if new_image.blank?
-    @item.image.attach(@item.image.blob) if @item.image.attached?
-  else
+    # 画像が選択されていない場合、既存の画像を保持する
+    if new_image.blank?
+      @item.image.attach(@item.image.blob) if @item.image.attached?
+    else
     # 新しい画像が送信された場合、既存の画像を置き換える
-    @item.image.purge
-    @item.image.attach(new_image)
-  end
+      @item.image.purge
+      @item.image.attach(new_image)
+    end
 
-  if @item.update(item_params.except(:image))
-    # 商品情報が正常に更新された場合の処理
-    redirect_to item_path(@item), notice: "商品情報が更新されました。"
-  else
-    # 商品情報の更新にエラーがある場合の処理
-    render 'edit'
+    if @item.update(item_params.except(:image))
+      # 商品情報が正常に更新された場合の処理
+      redirect_to item_path(@item), notice: "商品情報が更新されました。"
+    else
+      # 商品情報の更新にエラーがある場合の処理
+      render 'edit'
+    end
   end
-end
   
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,11 +29,14 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-  
+    
     # フォームから送信された画像を取得
     new_image = params[:item][:image]
-  
-    if new_image.present?
+    
+    # 画像が選択されていない場合、既存の画像を保持する
+    if new_image.blank?
+      @item.image.attach(@item.image.blob) if @item.image.attached?
+    else
       # 新しい画像が送信された場合、既存の画像を置き換える
       @item.image.purge
       @item.image.attach(new_image)
@@ -47,6 +50,7 @@ class ItemsController < ApplicationController
       render 'edit'
     end
   end
+  
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   
     if user_signed_in?
-      if current_user == @item.user && !@item.sold?
+      if current_user == @item.user
         # ユーザーがログインし、出品者かつ商品が売却済みでない場合は編集ページに遷移
       else
         redirect_to root_path
@@ -37,28 +37,29 @@ class ItemsController < ApplicationController
     end
   end        
 
-  def update
-    @item = Item.find(params[:id])
+def update
+  @item = Item.find(params[:id])
   
-    # フォームから送信された画像を取得
-    new_image = params[:item][:image]
+  # フォームから送信された画像を取得
+  new_image = params[:item][:image]
   
-    if new_image.present?
-      # 新しい画像が送信された場合、既存の画像を置き換える
-      @item.image.purge
-      @item.image.attach(new_image)
-    elsif !@item.image.attached?
-      # 画像が選択されておらず、既存の画像も存在しない場合はエラーとせず、何もしない
-    end
-  
-    if @item.update(item_params.except(:image))
-      # 商品情報が正常に更新された場合の処理
-      redirect_to @item, notice: "商品情報が更新されました。"
-    else
-      # 商品情報の更新にエラーがある場合の処理
-      render 'edit'
-    end
-  end 
+  # 画像が選択されていない場合、既存の画像を保持する
+  if new_image.blank?
+    @item.image.attach(@item.image.blob) if @item.image.attached?
+  else
+    # 新しい画像が送信された場合、既存の画像を置き換える
+    @item.image.purge
+    @item.image.attach(new_image)
+  end
+
+  if @item.update(item_params.except(:image))
+    # 商品情報が正常に更新された場合の処理
+    redirect_to item_path(@item), notice: "商品情報が更新されました。"
+  else
+    # 商品情報の更新にエラーがある場合の処理
+    render 'edit'
+  end
+end
   
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,10 @@ class ItemsController < ApplicationController
     @items = Item.all.order(created_at: :desc)
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+  
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,25 +25,20 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-    if @item.update_in_progress?
-      @item.discard_changes
-    end
-    redirect_to item_path(@item)
   end  
 
   def update
     @item = Item.find(params[:id])
-    
+  
     # フォームから送信された画像を取得
     new_image = params[:item][:image]
-    
-    # 画像が選択されていない場合、既存の画像を保持する
-    if new_image.blank?
-      @item.image.attach(@item.image.blob) if @item.image.attached?
-    else
+  
+    if new_image.present?
       # 新しい画像が送信された場合、既存の画像を置き換える
       @item.image.purge
       @item.image.attach(new_image)
+    elsif !@item.image.attached?
+      # 画像が選択されておらず、既存の画像も存在しない場合はエラーとせず、何もしない
     end
   
     if @item.update(item_params.except(:image))
@@ -53,9 +48,8 @@ class ItemsController < ApplicationController
       # 商品情報の更新にエラーがある場合の処理
       render 'edit'
     end
-  end
+  end 
   
-
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,7 +16,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @user_is_seller = user_signed_in? && current_user == @item.user
+
   end
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,15 @@ class ItemsController < ApplicationController
   def edit
     @item = Item.find(params[:id])
   end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to @item, notice: "商品情報が更新されました。"
+    else
+      render 'edit'
+    end
+  end
   
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,9 +18,4 @@ class Item < ApplicationRecord
   validates :shipping_id, presence: true, inclusion: { in: ->(item) { Shipping.where(id: 1..Float::INFINITY).pluck(:id) } }
   validates :prefecture_id, presence: true, inclusion: { in: ->(item) { Prefecture.where(id: 1..Float::INFINITY).pluck(:id) } }
   validates :delivery_day_id, presence: true, inclusion: { in: ->(item) { DeliveryDay.where(id: 1..Float::INFINITY).pluck(:id) } }
-  
-  # def sold_out?
-    # 例えば、商品の在庫が0の場合に売り切れとする
-    # self.item_id == 0
-  # end
 end

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,9 @@
-<% if resource.errors.any? %>
+<% if @item.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
+    <h2><%= pluralize(resource.errors.count, "error") %> prohibited this <%= resource.class.to_s.underscore.humanize.downcase %> from being saved:</h2>
     <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+      <% @item.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,6 +8,12 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: item_path(@item), local: true, method: :patch do |f| %>
+    <%# エラーメッセージを表示する %>
+    <% if @item.errors.any? %>
+      <div class="error-message">
+        <%= @item.errors.full_messages.join(", ") %>
+      </div>
+    <% end %>
       <%= render 'shared/error_messages', model: f.object %>
 
       <!-- 商品画像 -->

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -140,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
       <!-- 下部ボタン -->
       <div class="sell-btn-contents">
         <%= f.submit "変更する", class: "sell-btn" %>
-        <%= link_to 'もどる', "#", class: "back-btn" %>
+        <%= link_to 'もどる', item_path(@item), class: "back-btn" %>
       </div>
       <!-- /下部ボタン -->
     <% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -3,157 +3,155 @@ app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(@item), method: :put, local: true do |f| %>
+      <%= render 'shared/error_messages', model: f.object %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <!-- 商品画像 -->
+      <div class="img-upload">
+        <div class="weight-bold-text">
+          商品画像
+          <span class="indispensable">必須</span>
+        </div>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id: "item-image" %>
+        </div>
+      </div>
+      <!-- /商品画像 -->
 
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <!-- 商品名と商品説明 -->
+      <div class="new-items">
         <div class="weight-bold-text">
-          商品の説明
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-      </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
-        <div class="weight-bold-text">
-          カテゴリー
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_field :name, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :item_info, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000" %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
+      <!-- /商品名と商品説明 -->
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+      <!-- 商品の詳細 -->
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :category_id, Category.all, :id, :name, {}, class: "select-box", id: "item-category" %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :condition_id, Condition.all, :id, :name, {}, class: "select-box", id: "item-sales-status" %>
+        </div>
+      </div>
+      <!-- /商品の詳細 -->
+
+      <!-- 配送について -->
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :shipping_id, Shipping.all, :id, :name, {}, class: "select-box", id: "item-shipping-fee-status" %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: "select-box", id: "item-prefecture" %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :delivery_day_id, DeliveryDay.all, :id, :name, {}, class: "select-box", id: "item-scheduled-delivery" %>
+        </div>
+      </div>
+      <!-- /配送について -->
+
+      <!-- 販売価格 -->
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.number_field :price, class: "price-input", id: "item-price", placeholder: "例）300", in: 300..9_999_999 %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id="add-tax-price"></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id="profit"></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <!-- /販売価格 -->
+
+      <!-- 注意書き -->
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <!-- /注意書き -->
+
+      <!-- 下部ボタン -->
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する", class: "sell-btn" %>
+        <%= link_to 'もどる', "#", class: "back-btn" %>
+      </div>
+      <!-- /下部ボタン -->
+    <% end %>
   </div>
-  <% end %>
-
   <footer class="items-sell-footer">
     <ul class="menu">
       <li><a href="#">プライバシーポリシー</a></li>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
     <p class="inc">
       ©︎Furima,Inc.
     </p>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: edit_item_path(@item), local: true, method: :patch do |f| %>
+    <%= form_with model: @item, url: item_path(@item), local: true, method: :patch do |f| %>
       <%= render 'shared/error_messages', model: f.object %>
 
       <!-- 商品画像 -->

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -14,7 +14,6 @@ app/assets/stylesheets/items/new.css %>
         <%= @item.errors.full_messages.join(", ") %>
       </div>
     <% end %>
-      <%= render 'shared/error_messages', model: f.object %>
 
       <!-- 商品画像 -->
       <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: item_path(@item), method: :put, local: true do |f| %>
+    <%= form_with model: @item, url: edit_item_path(@item), local: true, method: :patch do |f| %>
       <%= render 'shared/error_messages', model: f.object %>
 
       <!-- 商品画像 -->

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,10 +29,9 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <% if user_signed_in? && current_user == @item.user %>
-          <%= link_to edit_item_path(@item) do %>
-            <button>商品の編集</button>
-          <% end %>
+        <%= link_to edit_item_path(@item), class: "your-button-class" do %>
+          <button class="your-button-class">商品の編集</button>
+        <% end %>
         <p class="or-text">or</p>
         <!-- 削除ボタンの条件分岐も同様に -->
         <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ <%= @item.price %> <!-- 価格を表示 -->
+        <%= @item.price %> <!-- 価格を表示 -->
       </span>
       <span class="item-postage">
         <%= shipping_fee_display(@item.shipping_id) %> <!-- 配送料負担を表示 -->
@@ -29,15 +29,13 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <%= link_to edit_item_path(@item), class: "your-button-class" do %>
-          <button class="your-button-class">商品の編集</button>
+        <%= link_to edit_item_path(@item), class: "your-button-class item-edit-button" do %>
+           商品の編集
         <% end %>
         <p class="or-text">or</p>
-        <!-- 削除ボタンの条件分岐も同様に -->
-        <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>
-          <button>削除</button>
+        <%= link_to item_path(@item), method: :delete, data: { confirm: "本当に削除しますか?" }, class: "item-delete-button btn-delete" do %>
+          削除
         <% end %>
-      <% end %>
       <% elsif current_user != @item.user %> 
         <!-- ログイン中かつ他の出品者の販売中商品の場合 -->
         <%= link_to "#" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,7 +33,6 @@
           <%= link_to edit_item_path(@item) do %>
             <button>商品の編集</button>
           <% end %>
-        <% end %>
         <p class="or-text">or</p>
         <!-- 削除ボタンの条件分岐も同様に -->
         <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,9 +29,7 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <%= link_to edit_item_path(@item) do %>
-          <button>商品の編集</button>
-        <% end %>
+        <%= link_to "商品の編集", edit_item_path(@item) %>
         <p class="or-text">or</p>
         <!-- 削除ボタンの条件分岐も同様に -->
         <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,7 +33,7 @@
            商品の編集
         <% end %>
         <p class="or-text">or</p>
-        <%= link_to item_path(@item), method: :delete, data: { confirm: "本当に削除しますか?" }, class: "item-delete-button btn-delete" do %>
+        <%# <%= link_to item_path(@item), method: :delete, data: { confirm: "本当に削除しますか?" }, class: "item-delete-button btn-delete" do %> 
           削除
         <% end %>
       <% elsif current_user != @item.user %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,9 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <%= link_to "商品の編集", edit_item_path(@item) %>
+        <%= link_to edit_item_path(@item) do %>
+          <button>商品の編集</button>
+        <% end %>6++0
         <p class="or-text">or</p>
         <!-- 削除ボタンの条件分岐も同様に -->
         <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <%= link_to "#" do %>
+        <%= link_to new_item_path do %>
           <button>商品の編集</button>
         <% end %>
         <p class="or-text">or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <%= link_to new_item_path do %>
+        <%= link_to edit_item_path(@item) do %>
           <button>商品の編集</button>
         <% end %>
         <p class="or-text">or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,14 +29,17 @@
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
-        <%= link_to edit_item_path(@item) do %>
-          <button>商品の編集</button>
+        <% if user_signed_in? && current_user == @item.user %>
+          <%= link_to edit_item_path(@item) do %>
+            <button>商品の編集</button>
+          <% end %>
         <% end %>
         <p class="or-text">or</p>
         <!-- 削除ボタンの条件分岐も同様に -->
         <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>
           <button>削除</button>
         <% end %>
+      <% end %>
       <% elsif current_user != @item.user %> 
         <!-- ログイン中かつ他の出品者の販売中商品の場合 -->
         <%= link_to "#" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
         <!-- ログイン中かつ出品者が自分の商品の場合 -->
         <%= link_to edit_item_path(@item) do %>
           <button>商品の編集</button>
-        <% end %>6++0
+        <% end %>
         <p class="or-text">or</p>
         <!-- 削除ボタンの条件分岐も同様に -->
         <%= link_to "#", method: :delete, data: { confirm: "本当に削除しますか?" }, class: "btn-delete" do %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,10 +1,11 @@
-<% if resource.errors.any? %>
+<% if @item.errors.any? %>
   <div id="error_explanation">
-    <h2><%= pluralize(resource.errors.count, "error") %> prohibited this <%= resource.class.to_s.underscore.humanize.downcase %> from being saved:</h2>
+    <h2><%= pluralize(@item.errors.count, "error") %> prohibited this <%= @item.class.to_s.underscore.humanize.downcase %> from being saved:</h2>
     <ul>
-      <% resource.errors.full_messages.each do |msg| %>
+      <% @item.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>
     </ul>
   </div>
 <% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
 
   # get 'purchases/new', to: 'purchases#new', as: 'new_purchase'
 
+  # 商品情報の編集画面へのルーティングを設定
+  get 'items/:id/edit', to: 'items#edit', as: 'edit_item'
+
   # Deviseの設定
   devise_for :users
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,13 @@ Rails.application.routes.draw do
   get 'items', to: 'items#index'
   
   # リソースとアクションの指定
-  resources :items, only: [:index, :new, :create, :show, :update, :destroy, :edit]
+  resources :items, only: [:index, :new, :create, :show, :destroy, :edit, :update]
 
-  # get 'purchases/new', to: 'purchases#new', as: 'new_purchase'
-  
+  # 商品情報の編集画面へのルーティングを設定
+  # get 'items/:id/edit', to: 'items#edit', as: 'edit_item'
+
   # 商品情報の更新アクション
-  put 'items/:id', to: 'items#update'
+  # patch 'items/:id', to: 'items#update'
   
   # Deviseの設定
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,18 +5,13 @@ Rails.application.routes.draw do
   get 'items', to: 'items#index'
   
   # リソースとアクションの指定
-  resources :items, only: [:index, :new, :create, :show, :update, :destroy]
+  resources :items, only: [:index, :new, :create, :show, :update, :destroy, :edit]
 
   # get 'purchases/new', to: 'purchases#new', as: 'new_purchase'
-
-  # 商品情報の編集画面へのルーティングを設定
-  get 'items/:id/edit', to: 'items#edit', as: 'edit_item'
   
   # 商品情報の更新アクション
-  patch 'items/:id', to: 'items#update'
-
+  put 'items/:id', to: 'items#update'
+  
   # Deviseの設定
   devise_for :users
 end
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   # get 'items/:id/edit', to: 'items#edit', as: 'edit_item'
 
   # 商品情報の更新アクション
-  # patch 'items/:id', to: 'items#update'
+  patch 'items/:id', to: 'items#update'
   
   # Deviseの設定
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   # 商品情報の編集画面へのルーティングを設定
   get 'items/:id/edit', to: 'items#edit', as: 'edit_item'
+  
+  # 商品情報の更新アクション
+  patch 'items/:id', to: 'items#update'
 
   # Deviseの設定
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,10 @@ Rails.application.routes.draw do
   get 'items', to: 'items#index'
   
   # リソースとアクションの指定
-  resources :items, only: [:index, :new, :create, :show, :destroy, :edit, :update]
-
+  resources :items, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
+    get :edit_item, on: :member
+  end
+  
   # 商品情報の編集画面へのルーティングを設定
   # get 'items/:id/edit', to: 'items#edit', as: 'edit_item'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get 'items', to: 'items#index'
   
   # リソースとアクションの指定
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :items, only: [:index, :new, :create, :show, :update, :destroy]
 
   # get 'purchases/new', to: 'purchases#new', as: 'new_purchase'
 


### PR DESCRIPTION
What (何)
ユーザーは商品情報を編集できる。
編集内容に関係なく、必須情報は維持される。
編集途中の情報は破棄されず、編集ページに戻れる。
出品者は自身の商品情報を編集できる。
出品者以外は他の商品情報編集ページにアクセスできない。
ログアウト状態のユーザーはログイン画面にリダイレクト。
商品情報の編集ページは出品ページと似た見た目。
既存情報は表示され、必要な変更が可能。
編集が完了すると、変更内容が表示。
入力エラー時にエラーメッセージが表示され、情報は保存されない。
入力エラーで戻っても、他の情報は保持。
同じエラーメッセージが複数回表示されない。

Why (なぜ)
ユーザーが正確な情報を保つため。
無駄な情報変更を防ぎ、手間を省くため。
編集中の情報を誤って破棄しないため。
出品者が商品情報を管理するため。
セキュリティとプライバシーを保護するため。
ログアウト状態のユーザーを認証し、セキュリティを確保。
一貫性を保つため。
既存情報を利用し、必要な変更を可能にするため。
変更内容を確認するため。
ユーザーがエラーを理解し、情報が保存されないことを保証。
エラー発生時に情報の損失を防ぐため。
ユーザーエクスペリエンスを向上させるため。


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/77a1cd28f3beb767b89e7bce9fc2e255
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/9366c18d0f9d628e6f8a0e439f3f13e7
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/b50bb26f7d908f99b04fab0b0bd72e06
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/dc665a5726cd3e79dba99ef359319179
ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/7b3f1af3abc34ac39a0a7946404ac4ca
ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/805d3847e1562cd462ecacde38b47b9d
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/e4ac1cecc4f5750cfaae605ef6894f65
