### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authetnticate_user!, only: [:new, :create, :destroy]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,17 @@ class ItemsController < ApplicationController
     @items = Item.all.order(created_at: :desc)
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+  
+    if current_user == @item.user
+      @item.destroy
+      redirect_to root_path, notice: "商品を削除しました。"
+    else
+      redirect_to root_path, alert: "他のユーザーの商品を削除できません。"
+    end
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
     @items = Item.all.order(created_at: :desc)
   end
 
-  def set_item
+  def destroy
     @item = Item.find(params[:id])
     
     if current_user == @item.user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,8 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
-    
     if current_user == @item.user
       @item.destroy
       redirect_to root_path, notice: "商品を削除しました。"

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,6 @@
 class ItemsController < ApplicationController
-<<<<<<< HEAD
   before_action :authetnticate_user!, only: [:new, :create, :destroy]
-=======
-  before_action :authetnticate_user!, only: [:new, :create, :desroy]
   before_action :set_item, only: [:show, :edit, :update]
->>>>>>> 64557f78ad6f202ee2bc4c340a4f7136c7022cf0
 
   def new
     @item = Item.new
@@ -29,13 +25,15 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
-  
+    
     if current_user == @item.user
       @item.destroy
       redirect_to root_path, notice: "商品を削除しました。"
     else
       redirect_to root_path, alert: "他のユーザーの商品を削除できません。"
-
+    end
+  end
+  
   def edit
     if current_user == @item.user
       # ユーザーがログインし、出品者かつ商品が売却済みでない場合は編集ページに遷移

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :destroy]
+  before_action :authetnticate_user!, only: [:new, :create, :destroy]
 
   def new
     @item = Item.new
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
     @items = Item.all.order(created_at: :desc)
   end
 
-  def destroy
+  def set_item
     @item = Item.find(params[:id])
   
     if current_user == @item.user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :destroy]
 
   def new
     @item = Item.new

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ <%= @item.price %> <!-- 価格を表示 -->
+        ¥<%= @item.price %> <!-- 価格を表示 -->
       </span>
       <span class="item-postage">
         <%= shipping_fee_display(@item.shipping_id) %> <!-- 配送料負担を表示 -->

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,6 @@
         <%= shipping_fee_display(@item.shipping_id) %> <!-- 配送料負担を表示 -->
       </span>
     </div>
-
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
@@ -33,17 +32,17 @@
            商品の編集
         <% end %>
         <p class="or-text">or</p>
-        <%# <%= link_to item_path(@item), method: :delete, data: { confirm: "本当に削除しますか?" }, class: "item-delete-button btn-delete" do %> 
+        <!-- 削除の部分はコメントアウトから外します -->
+        <%= link_to item_path(@item), method: :delete, data: { confirm: "本当に削除しますか?" }, class: "item-delete-button btn-delete" do %>
           削除
         <% end %>
-      <% elsif current_user != @item.user %> 
+      <% elsif current_user != @item.user %>
         <!-- ログイン中かつ他の出品者の販売中商品の場合 -->
         <%= link_to "#" do %>
           <button>購入画面に進む</button>
         <% end %>
       <% end %>
     <% end %>
-    <!-- //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう -->
 
     <div class="item-explain-box">
       <span>商品説明</span>
@@ -115,3 +114,4 @@
 </div>
 
 <%= render "shared/footer" %>
+


### PR DESCRIPTION
What (何をするのか):
商品情報の削除機能を実装する

Why (なぜそれをするのか):
ログイン状態のユーザーが、自身が出品した商品情報を削除できる必要があります。
商品情報の削除が完了したら、ユーザーをトップページに遷移させる必要があります。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/161f2790a946166f6b05a446605478e8